### PR TITLE
Improvements on a couple of style checks

### DIFF
--- a/Jubjubnest.Style.DotNet.Test/CommentTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/CommentTests.cs
@@ -43,7 +43,9 @@ namespace Jubjubnest.Style.DotNet.Test
                 int b = 0;
             " );
 
-			VerifyCSharpDiagnostic( code.Code, Warning( code, 1, 17, CommentAnalyzer.CommentedSegments ), Warning( code, 4, 17, CommentAnalyzer.CommentedSegments ) );
+			VerifyCSharpDiagnostic( code.Code,
+					Warning( code, 1, 17, CommentAnalyzer.CommentedSegments ),
+					Warning( code, 4, 17, CommentAnalyzer.CommentedSegments ) );
 		}
 
 		[TestMethod]

--- a/Jubjubnest.Style.DotNet.Test/Helpers/Code.cs
+++ b/Jubjubnest.Style.DotNet.Test/Helpers/Code.cs
@@ -66,5 +66,14 @@ namespace Jubjubnest.Style.DotNet.Test.Helpers
 		}
 	}" );
         }
-    }
+
+		public static CodeResult InNamespace( string code )
+		{
+			return new CodeResult(
+@"	namespace Namespace
+	{",
+		code,
+@"	}" );
+		}
+	}
 }

--- a/Jubjubnest.Style.DotNet.Test/LineTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/LineTests.cs
@@ -255,6 +255,17 @@ namespace Jubjubnest.Style.DotNet.Test
 			VerifyCSharpDiagnostic( code.Code, Warning( 7, 11, LineAnalyzer.UseWindowsLineEnding ) );
 		}
 
+		[TestMethod]
+		public void TestCodeWithAnonymousBlocks()
+		{
+			var code = Code.InMethod( @"
+				{
+					int i = 0;
+				}" );
+
+			VerifyCSharpDiagnostic( code.Code );
+		}
+
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{
 			return new LineCodeFixProvider();

--- a/Jubjubnest.Style.DotNet.Test/LineTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/LineTests.cs
@@ -266,6 +266,48 @@ namespace Jubjubnest.Style.DotNet.Test
 			VerifyCSharpDiagnostic( code.Code );
 		}
 
+		[TestMethod]
+		public void TestDisallowBaseConstructorOtherLine()
+		{
+			var code = Code.InClass( @"
+				public Test(
+					int i
+				)
+					: base( i )
+				{
+
+				}" );
+
+			VerifyCSharpDiagnostic( code.Code, Warning( code, 4, 6, LineAnalyzer.BaseConstructorCallSameLine ) );
+		}
+
+		[TestMethod]
+		public void TestAllowBaseConstructorSameLine()
+		{
+			var code = Code.InClass( @"
+				public Test(
+					int i
+				) : base( i )
+				{
+
+				}" );
+
+			VerifyCSharpDiagnostic( code.Code );
+		}
+
+		[TestMethod]
+		public void TestAllowBaseConstructorOtherLineWhenOneParameter()
+		{
+			var code = Code.InClass( @"
+				public Test( int i )
+					: base( i )
+				{
+
+				}" );
+
+			VerifyCSharpDiagnostic( code.Code );
+		}
+
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{
 			return new LineCodeFixProvider();

--- a/Jubjubnest.Style.DotNet.Test/NamingTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/NamingTests.cs
@@ -227,6 +227,13 @@ namespace Jubjubnest.Style.DotNet.Test
 					Warning( 1, 31, NamingAnalyzer.NameFilesAccordingToTypeNames, "Bar", "Bar.cs" ) );
 		}
 
+		[TestMethod]
+		public void TestNamesEndingInLetterAndNumber()
+		{
+			VerifyCSharpDiagnostic( @"namespace SomethingA1 { class Bar { } }",
+					new TestEnvironment { FileName = "Bar.cs" } );
+		}
+
 		[TestMethod, Ignore /* Folder name rules not implemented */ ]
 		public void TestWrongFolderName()
 		{
@@ -240,7 +247,7 @@ namespace Jubjubnest.Style.DotNet.Test
 
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
 		{
-            return new NamingAnalyzer();
+			return new NamingAnalyzer();
 		}
 	}
 }

--- a/Jubjubnest.Style.DotNet/CommentAnalyzer.cs
+++ b/Jubjubnest.Style.DotNet/CommentAnalyzer.cs
@@ -172,7 +172,7 @@ namespace Jubjubnest.Style.DotNet
 				lastInSegment = childNode;
 			}
 
-			// No more statements. We might need to process the last statmeent unless the
+			// No more statements. We might need to process the last statement unless the
 			// whole block was empty.
 			if( firstInSegment != null )
 			{
@@ -316,7 +316,8 @@ namespace Jubjubnest.Style.DotNet
 		private static void RequireComment(
 			SyntaxNodeAnalysisContext context,
 			SyntaxNode firstInSegment,
-			SyntaxNode lastInSegment )
+			SyntaxNode lastInSegment
+		)
 		{
 			// Try to find a leading comment for the segment.
 			var hasComments = false;

--- a/Jubjubnest.Style.DotNet/Jubjubnest.Style.DotNet.csproj
+++ b/Jubjubnest.Style.DotNet/Jubjubnest.Style.DotNet.csproj
@@ -87,7 +87,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Jubjubnest.Style.DotNet.0.1.19.0\analyzers\dotnet\cs\Jubjubnest.Style.DotNet.dll" />
+    <Analyzer Include="..\packages\Jubjubnest.Style.DotNet.0.1.41.0\analyzers\dotnet\cs\Jubjubnest.Style.DotNet.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>

--- a/Jubjubnest.Style.DotNet/LineAnalyzer.cs
+++ b/Jubjubnest.Style.DotNet/LineAnalyzer.cs
@@ -183,7 +183,8 @@ namespace Jubjubnest.Style.DotNet
 					statement.IsKind( SyntaxKind.WhileStatement ) ||
 					statement.IsKind( SyntaxKind.LockStatement ) ||
 					statement.IsKind( SyntaxKind.UncheckedStatement ) ||
-					statement.IsKind( SyntaxKind.UsingStatement ) )
+					statement.IsKind( SyntaxKind.UsingStatement ) ||
+					statement.IsKind( SyntaxKind.Block ) )
 				{
 					// Flow control statement. Skip.
 					continue;

--- a/Jubjubnest.Style.DotNet/NamingAnalyzer.cs
+++ b/Jubjubnest.Style.DotNet/NamingAnalyzer.cs
@@ -516,7 +516,7 @@ namespace Jubjubnest.Style.DotNet
 			|
 				[0-9]+			# Numbering.
 			|
-				[A-Z]$			# Allow single capital character in the end.
+				[A-Z][0-9]*$			# Allow single capital character and numbering in the end.
 			)+$
 		", RegexOptions.IgnorePatternWhitespace );
 

--- a/Jubjubnest.Style.DotNet/Resources.Designer.cs
+++ b/Jubjubnest.Style.DotNet/Resources.Designer.cs
@@ -62,6 +62,24 @@ namespace Jubjubnest.Style.DotNet {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Move the constructor call to its right place..
+        /// </summary>
+        internal static string BaseConstructorCallSameLine_Message {
+            get {
+                return ResourceManager.GetString("BaseConstructorCallSameLine_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Base constructor call should be on the same line as the last closing brace of the parameter list if the parameters are on their own lines. Otherwise it should be on its own line..
+        /// </summary>
+        internal static string BaseConstructorCallSameLine_Title {
+            get {
+                return ResourceManager.GetString("BaseConstructorCallSameLine_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
         internal static string BracesOnTheirOwnLine_Description {
@@ -341,7 +359,7 @@ namespace Jubjubnest.Style.DotNet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add Exception suffix to &apos;{0}&apos; exception type name..
+        ///   Looks up a localized string similar to Add &apos;Exception&apos; suffix to &apos;{0}&apos; exception type name..
         /// </summary>
         internal static string NameExceptionsWithExceptionSuffix_Message {
             get {
@@ -350,7 +368,7 @@ namespace Jubjubnest.Style.DotNet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exception names should end with Exception.
+        ///   Looks up a localized string similar to Exception names should end with &apos;Exception&apos;.
         /// </summary>
         internal static string NameExceptionsWithExceptionSuffix_Title {
             get {

--- a/Jubjubnest.Style.DotNet/Resources.resx
+++ b/Jubjubnest.Style.DotNet/Resources.resx
@@ -462,4 +462,10 @@
   <data name="NameReadOnlyFieldsWithCamelCase_Title" xml:space="preserve">
     <value>Read-only fields should be named with camelCasing</value>
   </data>
+  <data name="BaseConstructorCallSameLine_Message" xml:space="preserve">
+    <value>Move the constructor call to its right place.</value>
+  </data>
+  <data name="BaseConstructorCallSameLine_Title" xml:space="preserve">
+    <value>Base constructor call should be on the same line as the last closing brace of the parameter list if the parameters are on their own lines. Otherwise it should be on its own line.</value>
+  </data>
 </root>

--- a/Jubjubnest.Style.DotNet/packages.config
+++ b/Jubjubnest.Style.DotNet/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Jubjubnest.Style.DotNet" version="0.1.19.0" targetFramework="portable45-net45+win8" />
+  <package id="Jubjubnest.Style.DotNet" version="0.1.41.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis" version="1.2.2" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.2.2" targetFramework="portable45-net45+win8" />


### PR DESCRIPTION
Improved two situations:

* Name ends in both an uppercase letter and a number. I think this should not cause a warning, as you really can't lowercase a number.
* If there is a simple block to limit the scope, there should not be a warning about double indent.

Also updated the version of the code analyzer.