### PR TITLE
Allow the "while" of do-while to share the line with closing brace

### DIFF
--- a/Jubjubnest.Style.DotNet.Test/LineTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/LineTests.cs
@@ -150,6 +150,18 @@ namespace Jubjubnest.Style.DotNet.Test
 		}
 
 		[TestMethod]
+		public void TestCloseBraceWithWhile()
+		{
+			var code = Code.InMethod( @"
+				do
+				{
+					// Looping.
+				} while( true );" );
+
+			VerifyCSharpDiagnostic( code.Code );
+		}
+
+		[TestMethod]
 		public void TestTwoLinePropertyWithBracesOnSharedLines()
 		{
 			var code = Code.InClass( @"

--- a/Jubjubnest.Style.DotNet/LineAnalyzer.cs
+++ b/Jubjubnest.Style.DotNet/LineAnalyzer.cs
@@ -317,7 +317,7 @@ namespace Jubjubnest.Style.DotNet
 		/// such as closing parentheses, which can then be followed by things closing parentheses can be followed by
 		/// in other places - however keywords such as 'else' are not allowed to follow closing braces.
 		/// </summary>
-		private static readonly Regex VALID_CLOSE_BRACE_REGEX = new Regex( @"^\s*\}\s*($|[);,]|//)" );
+		private static readonly Regex VALID_CLOSE_BRACE_REGEX = new Regex( @"^\s*\}\s*($|[);,]|//|while)" );
 
 		/// <summary>
 		/// Check whether the braces are on their own lines.


### PR DESCRIPTION
Allow the "while" of do-while to appear on the same line as the closing brace.