### PR TITLE
Allow declaration of a static helper class for an enumeration

### DIFF
--- a/Jubjubnest.Style.DotNet.Test/NamingTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/NamingTests.cs
@@ -247,13 +247,18 @@ namespace Jubjubnest.Style.DotNet.Test
 		}
 
 		[TestMethod]
-		public void TestStaticHelperClassAllowedForEnumerations()
+		public void TestStaticHelperClassAllowedForEnumerations(
+		)
 		{
-			VerifyCSharpDiagnostic(
+			var validHelperPostfixes = new string[] { "Helper", "Extension", "Extensions" };
+			foreach( var postfix in validHelperPostfixes )
+			{
+				VerifyCSharpDiagnostic(
 
-					@"namespace TestProject { enum Bar {} public static class BarHelper {} }",
+					$"namespace TestProject {{ enum Bar {{}} public static class Bar{postfix} {{}} }}",
 
 					new TestEnvironment { FileName = "Bar" } );
+			}
 		}
 
 		[TestMethod]

--- a/Jubjubnest.Style.DotNet.Test/NamingTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/NamingTests.cs
@@ -247,6 +247,38 @@ namespace Jubjubnest.Style.DotNet.Test
 		}
 
 		[TestMethod]
+		public void TestStaticHelperClassAllowedForEnumerations()
+		{
+			VerifyCSharpDiagnostic(
+
+					@"namespace TestProject { enum Bar {} public static class BarHelper {} }",
+
+					new TestEnvironment { FileName = "Bar" } );
+		}
+
+		[TestMethod]
+		public void TestEnumerationsCannotActAsHelpersForEnumerations()
+		{
+			VerifyCSharpDiagnostic(
+
+					@"namespace TestProject { enum Bar {} public enum BarHelper {} }",
+
+					new TestEnvironment { FileName = "Bar" },
+					Warning( 1, 49, NamingAnalyzer.NameFilesAccordingToTypeNames, "BarHelper", "BarHelper.cs" ) );
+		}
+
+		[TestMethod]
+		public void TestNonStaticClassIsNotHelperForEnumerations()
+		{
+			VerifyCSharpDiagnostic(
+
+					@"namespace TestProject { enum Bar {} class BarHelper { public static int GetInt() => 5; } }",
+
+					new TestEnvironment { FileName = "Bar" },
+					Warning( 1, 43, NamingAnalyzer.NameFilesAccordingToTypeNames, "BarHelper", "BarHelper.cs" ) );
+		}
+
+		[TestMethod]
 		public void TestWrongFileNameInDirectory()
 		{
 			VerifyCSharpDiagnostic(

--- a/Jubjubnest.Style.DotNet/NamingAnalyzer.cs
+++ b/Jubjubnest.Style.DotNet/NamingAnalyzer.cs
@@ -375,8 +375,10 @@ namespace Jubjubnest.Style.DotNet
 				return false;
 
 			// Helper must be named as a helper.
+			var validHelperPostfixes = new string[] { "Helper", "Extension", "Extensions" };
 			string identifier = helperCandidate.Identifier.Text;
-			if( identifier.EndsWith( "Helper" ) == false )
+			var helperPostfix = validHelperPostfixes.SingleOrDefault( postfix => identifier.EndsWith( postfix ) );
+			if( helperPostfix == default( string ) )
 				return false;
 
 			// A helper class must be declared as static.
@@ -388,7 +390,7 @@ namespace Jubjubnest.Style.DotNet
 				return false;
 
 			// Does the node actually have a sibling that it can "help"?
-			string expectedEnumerationName = identifier.Substring( 0, identifier.Length - "Helper".Length );
+			string expectedEnumerationName = identifier.Substring( 0, identifier.Length - helperPostfix.Length );
 			bool isHelper = GetSiblingEnumerations( node )
 							.Any( siblingEnum => siblingEnum.Identifier.Text == expectedEnumerationName );
 			return isHelper;


### PR DESCRIPTION
It is more likely that the helper class will be updated with the enum if they both are in the same file. Hence it should be allowed.