### PR TITLE
Topic/method declaration closing parenthesis

### DIFF
--- a/Jubjubnest.Style.DotNet.Test/LineTests.cs
+++ b/Jubjubnest.Style.DotNet.Test/LineTests.cs
@@ -290,6 +290,21 @@ namespace Jubjubnest.Style.DotNet.Test
 		}
 
 		[TestMethod]
+		public void TestConstructorParameterParenWrongColumn()
+		{
+			var code = Code.InClass( @"
+				public Test(
+					string a,
+					string b
+					)
+				{
+				}" );
+
+			// Closing paren must be aligned with opening curly bracket.
+			VerifyCSharpDiagnostic( code.Code, Warning( 9, 6, LineAnalyzer.ClosingParameterParenthesesOnTheirOwnLines ) );
+		}
+
+		[TestMethod]
 		public void TestCodeWithUnixNewlines()
 		{
 			var code = Code.InMethod( "int a = 0;\nint b = 0;" );

--- a/Jubjubnest.Style.DotNet.Vsix/Jubjubnest.Style.DotNet.Vsix.csproj
+++ b/Jubjubnest.Style.DotNet.Vsix/Jubjubnest.Style.DotNet.Vsix.csproj
@@ -1,8 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>14.0</OldToolsVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -59,7 +64,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\LICENSE">
+    <Content Include="LICENSE.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/Jubjubnest.Style.DotNet.Vsix/LICENSE.txt
+++ b/Jubjubnest.Style.DotNet.Vsix/LICENSE.txt
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright (c) 2016 Mikko Rantanen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Jubjubnest.Style.DotNet.Vsix/source.extension.vsixmanifest
+++ b/Jubjubnest.Style.DotNet.Vsix/source.extension.vsixmanifest
@@ -1,20 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-	<Metadata>
-		<Identity Id="Jubjubnest.Style.DotNet..0b2776f6-62be-4a7a-939f-52dca888a6ae" Version="0.0.1" Language="en-US" Publisher="Rantanen" />
-		<DisplayName>Jubjubnest.Style.DotNet</DisplayName>
-		<Description xml:space="preserve">A style checking diagnostic extension for the .NET Compiler Platform ("Roslyn").</Description>
-		<MoreInfo>https://github.com/Rantanen/Jubjubnest.Style.DotNet</MoreInfo>
-		<License>LICENSE</License>
-	</Metadata>
-	<Installation>
-		<InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
-	</Installation>
-	<Dependencies>
-		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-	</Dependencies>
-	<Assets>
-		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Jubjubnest.Style.DotNet" Path="|Jubjubnest.Style.DotNet|" />
-		<Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="Jubjubnest.Style.DotNet" Path="|Jubjubnest.Style.DotNet|" />
-	</Assets>
+    <Metadata>
+        <Identity Id="Jubjubnest.Style.DotNet..0b2776f6-62be-4a7a-939f-52dca888a6ae" Version="0.0.1" Language="en-US" Publisher="Rantanen" />
+        <DisplayName>Jubjubnest.Style.DotNet</DisplayName>
+        <Description xml:space="preserve">A style checking diagnostic extension for the .NET Compiler Platform ("Roslyn").</Description>
+        <MoreInfo>https://github.com/Rantanen/Jubjubnest.Style.DotNet</MoreInfo>
+        <License>LICENSE.txt</License>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Jubjubnest.Style.DotNet" Path="|Jubjubnest.Style.DotNet|" />
+        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="Jubjubnest.Style.DotNet" Path="|Jubjubnest.Style.DotNet|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.Net.Component.4.TargetingPack" Version="[15.6.27406.0,16.0)" DisplayName=".NET Framework 4 targeting pack" />
+    </Prerequisites>
 </PackageManifest>

--- a/Jubjubnest.Style.DotNet/Resources.Designer.cs
+++ b/Jubjubnest.Style.DotNet/Resources.Designer.cs
@@ -152,7 +152,7 @@ namespace Jubjubnest.Style.DotNet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move the parameter list parenthesis on its own line..
+        ///   Looks up a localized string similar to Move the parameter list parenthesis on its own line, aligned with curly bracket..
         /// </summary>
         internal static string ClosingParameterParenthesesOnTheirOwnLines_Message {
             get {
@@ -161,7 +161,7 @@ namespace Jubjubnest.Style.DotNet {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple parameter list parenthesis should be on their own line.
+        ///   Looks up a localized string similar to Multiple parameter list parenthesis should be on their own line, aligned with opening curly bracket..
         /// </summary>
         internal static string ClosingParameterParenthesesOnTheirOwnLines_Title {
             get {

--- a/Jubjubnest.Style.DotNet/Resources.resx
+++ b/Jubjubnest.Style.DotNet/Resources.resx
@@ -439,10 +439,10 @@
     <value />
   </data>
   <data name="ClosingParameterParenthesesOnTheirOwnLines_Message" xml:space="preserve">
-    <value>Move the parameter list parenthesis on its own line.</value>
+    <value>Move the parameter list parenthesis on its own line, aligned with curly bracket.</value>
   </data>
   <data name="ClosingParameterParenthesesOnTheirOwnLines_Title" xml:space="preserve">
-    <value>Multiple parameter list parenthesis should be on their own line</value>
+    <value>Multiple parameter list parenthesis should be on their own line, aligned with opening curly bracket.</value>
   </data>
   <data name="SpacesNotWithinBrackets_Description" xml:space="preserve">
     <value />


### PR DESCRIPTION
Added check to verify the column location of method declaration closing parenthesis when there are several parameters in the function.

Now creates a warning:
             public void GetContainerInvalidParameter(
                    string name,
                    string getStatus
                    )
             {

Right according to style guide, no warning:
             public void GetContainerInvalidParameter(
                    string name,
                    string getStatus
             )
             {

Some changes were also required to make the solution work with Visual Studio 2017. I'm not sure why the prerequisites needed to be added or why the relative path to the LICENSE file did not work, but the solution would not compile without those changes.